### PR TITLE
Change verbosity of logging

### DIFF
--- a/lib/origami/parser.rb
+++ b/lib/origami/parser.rb
@@ -57,7 +57,7 @@ module Origami
             #Default options values
             @options =
             {
-                verbosity: VERBOSE_INFO, # Verbose level.
+                verbosity: VERBOSE_QUIET, # Verbose level.
                 ignore_errors: true,     # Try to keep on parsing when errors occur.
                 callback: Proc.new {},   # Callback procedure whenever a structure is read.
                 logger: STDERR,          # Where to output parser messages.


### PR DESCRIPTION
Change verbosity default to quiet, so that instances of PDF parsing don't spam Travis logs. 
Currently, within Travis CL when running tests on parcelbright-web, the logs are completely spammed with [info ] statements which happen because the verbosity is set to Info instead of quiet. 

This is the simplest change that will fix the issue. 